### PR TITLE
Fix multi-choice result logic

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -106,26 +106,23 @@ class GameServer:
         
         # Đếm số lượng mỗi lựa chọn
         choice_counts = {choice: len(players) for choice, players in choices.items()}
-        
-        # Nếu chỉ có 1 loại lựa chọn -> tất cả hòa
-        if len(choice_counts) == 1:
-            for choice, players in choices.items():
+
+        # Nếu tất cả chọn giống nhau hoặc có đủ cả 3 lựa chọn -> hòa
+        if len(choice_counts) == 1 or len(choice_counts) == 3:
+            for players in choices.values():
                 for player in players:
                     results[player] = 'draw'
             return results
-        
-        # Xác định lựa chọn thắng
+
+        # Xác định lựa chọn thắng khi chỉ có 2 loại lựa chọn
         winning_choice = None
         if 'rock' in choice_counts and 'scissors' in choice_counts:
-            if choice_counts['rock'] > 0 and choice_counts['scissors'] > 0:
-                winning_choice = 'rock'
-        if 'scissors' in choice_counts and 'paper' in choice_counts:
-            if choice_counts['scissors'] > 0 and choice_counts['paper'] > 0:
-                winning_choice = 'scissors'
-        if 'paper' in choice_counts and 'rock' in choice_counts:
-            if choice_counts['paper'] > 0 and choice_counts['rock'] > 0:
-                winning_choice = 'paper'
-        
+            winning_choice = 'rock'
+        elif 'scissors' in choice_counts and 'paper' in choice_counts:
+            winning_choice = 'scissors'
+        elif 'paper' in choice_counts and 'rock' in choice_counts:
+            winning_choice = 'paper'
+
         # Phân bổ kết quả
         for choice, players in choices.items():
             for player in players:
@@ -135,7 +132,7 @@ class GameServer:
                     results[player] = 'draw'
                 else:
                     results[player] = 'lose'
-        
+
         return results
     
     def update_scores(self, room: GameRoom, results: Dict[websockets.WebSocketServerProtocol, str]):


### PR DESCRIPTION
## Summary
- ensure rock-paper-scissors results are a draw when all three options are chosen
- simplify winner selection when only two move types are present

## Testing
- `python -m py_compile backend/server.py`
- `python - <<'PY'
from backend.server import GameServer
class Dummy: pass
server = GameServer()

p1,p2,p3 = Dummy(), Dummy(), Dummy()
choices = {'rock':[p1],'paper':[p2],'scissors':[p3]}
print(server.compare_choices(choices))

choices2 = {'rock':[p1], 'scissors':[p2]}
print(server.compare_choices(choices2))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689af3c239f88331b2d442607f8b4888