### PR TITLE
Fix server script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install websockets
 
 ```bash
 cd backend
-python sever.py
+python server.py
 ```
 
 Server sẽ chạy tại `ws://localhost:8081`

--- a/start_server.bat
+++ b/start_server.bat
@@ -10,6 +10,6 @@ pip install -r requirements.txt
 echo.
 echo Dang khoi dong server...
 cd backend
-python sever.py
+python server.py
 
-pause 
+pause


### PR DESCRIPTION
## Summary
- correct server start command in README
- fix batch script to run `server.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689af4fab7e483318a20e82df31dd07f